### PR TITLE
Attempt to fix printer timing issue

### DIFF
--- a/printer/printer-server/src/printer-queue.ts
+++ b/printer/printer-server/src/printer-queue.ts
@@ -12,7 +12,7 @@ export class PrinterQueue {
         this.printServerId = printServerId;
         this.printQueueDto = printQueueDto;
         for (let printer of printQueueDto.printers) {
-            this.printers.push(new Printer(printer.mac, printer.name));
+            this.printers.push(Printer.getOrCreateInstance(printer.mac, printer.name));
         }
         this.nextPrintQueueJobConnection = SocketApi.connectToPrintQueueNextJob(
             process.env.PRINTER_QUEUE_SERVER_BASE_URL!,


### PR DESCRIPTION
## Overview

Fixes a timing issue bug where receipts may have come out double for takeaway orders

### Related Jira Story

KAN-63

### Printer Changes

There is a weird bug where sometimes for takeaway order receipts came out double. I believe this is because we send two print jobs to the printer in really close succession in the takeaway order.

## Definition of Done

- [x] The feature must be fully tested and all specified requirements being met as outlined in the feature description.
- [ ] Unit and integrations test must be written for any business logic.
- [x] Sufficient negative tests must be included to assess the robustness and error handling capabilities of the code.
- [x] The pull request must be reviewed and approved by at least one codeowner of the modified files.
- [x] All pipelines on the pull request succeed.
- [x] Refactoring on the code has taken place.

## Additional Notes

Since this is a timing issue this is very hard to test and reproduce, I hope this fixes it.
---

Please review the above changes. Upon approval, please squash the commits following the guidelines before merging to the main branch.
