### PR TITLE
KAN-190 Implement fix for ingredient delete issue

### DIFF
--- a/backend/src/main/kotlin/ch/zhaw/pm4/simonsays/service/IngredientService.kt
+++ b/backend/src/main/kotlin/ch/zhaw/pm4/simonsays/service/IngredientService.kt
@@ -30,6 +30,7 @@ class IngredientService(
             throw ResourceInUseException("Ingredient is used in menu items and cannot be deleted")
         }
         ingredientRepository.deleteById(id)
+        ingredientRepository.flush()
     }
 
     fun createUpdateIngredient(ingredient: IngredientCreateUpdateDTO, eventId: Long): IngredientDTO {

--- a/backend/src/main/kotlin/ch/zhaw/pm4/simonsays/service/IngredientService.kt
+++ b/backend/src/main/kotlin/ch/zhaw/pm4/simonsays/service/IngredientService.kt
@@ -4,6 +4,7 @@ import ch.zhaw.pm4.simonsays.api.mapper.IngredientMapper
 import ch.zhaw.pm4.simonsays.api.types.IngredientCreateUpdateDTO
 import ch.zhaw.pm4.simonsays.api.types.IngredientDTO
 import ch.zhaw.pm4.simonsays.entity.Ingredient
+import ch.zhaw.pm4.simonsays.entity.Station
 import ch.zhaw.pm4.simonsays.exception.ResourceInUseException
 import ch.zhaw.pm4.simonsays.exception.ResourceNotFoundException
 import ch.zhaw.pm4.simonsays.repository.IngredientRepository
@@ -13,7 +14,8 @@ import org.springframework.stereotype.Service
 class IngredientService(
     private val ingredientRepository: IngredientRepository,
     private val ingredientMapper: IngredientMapper,
-    private val eventService: EventService
+    private val eventService: EventService,
+    private val stationService: StationService
 ) {
 
     fun listIngredients(eventId: Long): List<IngredientDTO> {
@@ -28,6 +30,11 @@ class IngredientService(
         val ingredient = getIngredientEntity(id, eventId)
         if (!ingredient.menuItems.isNullOrEmpty()) {
             throw ResourceInUseException("Ingredient is used in menu items and cannot be deleted")
+        }
+        val stations: List<Station> = stationService.getStationAssociatedWithIngredient(ingredientId = id)
+        stations.forEach { station ->
+            station.ingredients = station.ingredients.filter { ingredient -> ingredient.id != id }
+            stationService.updateStationEntity(station)
         }
         ingredientRepository.deleteById(id)
         ingredientRepository.flush()

--- a/backend/src/main/kotlin/ch/zhaw/pm4/simonsays/service/StationService.kt
+++ b/backend/src/main/kotlin/ch/zhaw/pm4/simonsays/service/StationService.kt
@@ -41,6 +41,10 @@ class StationService(
         return stationMapper.mapToStationDTO(station)
     }
 
+    fun updateStationEntity(station: Station):Station {
+        return stationRepository.saveAndFlush(station)
+    }
+
     fun createUpdateStation(station: StationCreateUpdateDTO, eventId: Long): StationDTO {
         val event = eventService.getEvent(eventId)
         var ingredients: List<Ingredient> = listOf()

--- a/backend/src/test/kotlin/ch/zhaw/pm4/simonsays/IngredientTest.kt
+++ b/backend/src/test/kotlin/ch/zhaw/pm4/simonsays/IngredientTest.kt
@@ -8,6 +8,7 @@ import ch.zhaw.pm4.simonsays.exception.ResourceNotFoundException
 import ch.zhaw.pm4.simonsays.repository.IngredientRepository
 import ch.zhaw.pm4.simonsays.service.EventService
 import ch.zhaw.pm4.simonsays.service.IngredientService
+import ch.zhaw.pm4.simonsays.service.StationService
 import com.ninjasquad.springmockk.MockkBean
 import io.mockk.every
 import io.mockk.mockk
@@ -24,13 +25,17 @@ class IngredientTest {
     @MockkBean(relaxed = true)
     protected lateinit var eventService: EventService
 
+    @MockkBean(relaxed = true)
+    protected lateinit var stationService: StationService
+
     private lateinit var ingredientService: IngredientService
 
     @BeforeEach
     fun setup() {
         ingredientRepository = mockk(relaxed = true)
         eventService = mockk(relaxed = true)
-        ingredientService = IngredientService(ingredientRepository, IngredientMapperImpl(), eventService)
+        stationService = mockk(relaxed = true)
+        ingredientService = IngredientService(ingredientRepository, IngredientMapperImpl(), eventService, stationService)
     }
 
     @Test

--- a/backend/src/test/kotlin/ch/zhaw/pm4/simonsays/factory/IngredientFactory.kt
+++ b/backend/src/test/kotlin/ch/zhaw/pm4/simonsays/factory/IngredientFactory.kt
@@ -23,7 +23,7 @@ class IngredientFactory(
             menuItems = null,
             stations = null
         )
-        return ingredientRepository.save(ingredient)
+        return ingredientRepository.saveAndFlush(ingredient)
     }
 
 }


### PR DESCRIPTION
closes KAN-198 Implement fix for ingredient delete issue

## Overview

Fixed removing an ingredient when mapped to a station. Removing the relationship first and then deleting the ingredient fixes the issue.

### Related Jira Story

https://simonsays-zhaw.atlassian.net/browse/KAN-198?atlOrigin=eyJpIjoiNDllZWFmNmY1ODUzNDNmNWIxYzZkNWZiMDMwMjQyYWQiLCJwIjoiaiJ9

### Backend Changes

- Added method to remove the ingredient - station relationship before deleting the ingredient itself.

## Definition of Done

- [x] The feature must be fully tested and all specified requirements being met as outlined in the feature description.
- [x] Unit and integrations test must be written for any business logic.
- [x] Sufficient negative tests must be included to assess the robustness and error handling capabilities of the code.
- [x] The pull request must be reviewed and approved by at least one codeowner of the modified files.
- [x] All pipelines on the pull request succeed.
- [x] Refactoring on the code has taken place.

Please review the above changes. Upon approval, please squash the commits following the guidelines before merging to the main branch.
